### PR TITLE
add errorOrder to adaptive integrators

### DIFF
--- a/src/js/Physics/Integrators/RKN64.js
+++ b/src/js/Physics/Integrators/RKN64.js
@@ -4,6 +4,8 @@ export default class extends adaptiveRknBase {
   constructor(params) {
     super(params);
 
+    this.errorOrder = 6;
+
     this.coefficients = [
       [1/200],
       [-1/2200, 1/22],

--- a/src/js/Physics/Integrators/adaptiveRknBase.js
+++ b/src/js/Physics/Integrators/adaptiveRknBase.js
@@ -98,8 +98,7 @@ export default class extends rknBase {
       var [p, v, pHat] = this.generateVectors(s, k);
 
       error = this.calculateError(p, pHat);
-      
-      const temp = Math.pow(2*error / this.tol, 1/6);
+      const temp = Math.pow(2*error / this.tol, 1/(this.errorOrder));
       if (temp > 0.2){
         this.dt = this.dt / temp;
       } else{


### PR DESCRIPTION
Fix so that the order of the integrator is accounted for when calculating the new time step