### PR TITLE
Add yoshida6 integrator

### DIFF
--- a/src/js/Physics/Integrators/PEFRL.js
+++ b/src/js/Physics/Integrators/PEFRL.js
@@ -55,17 +55,18 @@ export default class extends Euler {
 
     const s = this.getStateVectors(this.masses);
 
-    const p1 = this.generatePositionVectors(s, s, a1);
-    const v1 = this.generateVelocityVectors(p1, s, a2);
-    const p2 = this.generatePositionVectors(p1, v1, a3);
-    const v2 = this.generateVelocityVectors(p2, v1, a4);
-    const p3 = this.generatePositionVectors(p2, v2, a5);
-    const v3 = this.generateVelocityVectors(p3, v2, a4);
-    const p4 = this.generatePositionVectors(p3, v3, a3);
-    const v4 = this.generateVelocityVectors(p4, v3, a2);
-    const p5 = this.generatePositionVectors(p4, v4, a1);
+    const pCoeffs = [a1, a3, a5, a3, a1];
+    const vCoeffs = [a2, a4, a4, a2];
 
-    this.updateStateVectors(p5, v4);
+    let p = s;
+    let v = s;
+    const coeffsLen = vCoeffs.length;
+    for (let i = 0; i < coeffsLen; i++){
+      p = this.generatePositionVectors(p, v, pCoeffs[i]);
+      v = this.generateVelocityVectors(p, v, vCoeffs[i]);
+    }
+    p = this.generatePositionVectors(p, v, pCoeffs[coeffsLen]);
+    this.updateStateVectors(p, v);
 
     this.incrementElapsedTime();
   }

--- a/src/js/Physics/Integrators/Yoshida6.js
+++ b/src/js/Physics/Integrators/Yoshida6.js
@@ -1,0 +1,59 @@
+import Euler from './Euler';
+
+export default class extends Euler {
+  generatePositionVectors(p, v, dt) {
+    const pFinal = [];
+    const vLen = v.length;
+
+    for (let i = 0; i < vLen; i++) {
+      let vI = v[i];
+      let pI = p[i];
+      pFinal[i] = {
+        x: pI.x + dt * vI.vx,
+        y: pI.y + dt * vI.vy,
+        z: pI.z + dt * vI.vz
+      };
+    }
+
+    return pFinal;
+  }
+
+  generateVelocityVectors(p, v, dt) {
+    const vFinal = [];
+    const vLen = v.length;
+
+    const a = this.generateAccelerationVectors(p);
+
+    for (let i = 0; i < vLen; i++) {
+      let vI = v[i];
+      let aI = a[i];
+
+      vFinal[i] = {
+        vx: vI.vx + dt * aI.ax,
+        vy: vI.vy + dt * aI.ay,
+        vz: vI.vz + dt * aI.az
+      };
+    }
+
+    return vFinal;
+  }
+
+  iterate() {
+    const s = this.getStateVectors(this.masses);
+
+    const pCoeffs = [0.74409614601461,-0.425227929490565,0.2762016693478,-0.0029155067911599275,-1.4465510537023341,1.4478689195210459,1.4451324786403945,-1.5386047235397915,-1.5386047235397915,1.4451324786403945,1.4478689195210459,-1.4465510537023341,-0.0029155067911599275,0.2762016693478,-0.425227929490565,0.74409614601461];
+    const vCoeffs = [1.48819229202922,-2.33864815101035,2.89105148970595,-2.89688250328827,0.00378039588360192,2.89195744315849,-0.00169248587770116,-3.075516961201882,-0.00169248587770116,2.89195744315849,0.00378039588360192,-2.89688250328827,2.89105148970595,-2.33864815101035,1.48819229202922];
+
+    let p = s;
+    let v = s;
+    const coeffsLen = vCoeffs.length;
+    for (let i = 0; i < coeffsLen; i++){
+      p = this.generatePositionVectors(p, v, this.dt*pCoeffs[i]);
+      v = this.generateVelocityVectors(p, v, this.dt*vCoeffs[i]);
+    }
+    p = this.generatePositionVectors(p, v, this.dt*pCoeffs[coeffsLen]);
+    this.updateStateVectors(p, v);
+
+    this.incrementElapsedTime();
+  }
+}

--- a/src/js/Physics/Integrators/index.js
+++ b/src/js/Physics/Integrators/index.js
@@ -9,6 +9,7 @@ import Nystrom5 from './Nystrom5';
 import Nystrom6 from './Nystrom6';
 import RKN64 from './RKN64';
 import RKN12 from './RKN12';
+import Yoshida6 from './Yoshida6';
 
 export const integrators = [
   'RK4',
@@ -21,7 +22,8 @@ export const integrators = [
   'Nystrom5',
   'Nystrom6',
   'RKN64',
-  'RKN12'
+  'RKN12',
+  'Yoshida6'
 ];
 
 export default function(integrator, config) {
@@ -48,6 +50,8 @@ export default function(integrator, config) {
       return new RKN64(config);
     case 'RKN12':
       return new RKN12(config);
+    case 'Yoshida6':
+      return new Yoshida6(config); 
     default:
       return new RK4(config);
   }


### PR DESCRIPTION
Yoshida6 is a symplectic integrator similiar to PEFRL in structure but it is of order 6 instead of 4. So for long time simulations this may be a better choice. 🚀 I also refactored the PEFRL code so I could reuse it for this as well.

I'm starting to run out of ideas for new integrators 😅 do you miss any special one? Everything after RKN12 feels so tame 🤣 