### PR TITLE
add KahanLi8 symplectic integrator

### DIFF
--- a/src/js/Physics/Integrators/KahanLi8.ts
+++ b/src/js/Physics/Integrators/KahanLi8.ts
@@ -1,0 +1,106 @@
+import Euler from './Euler';
+import { VectorType } from '../types';
+
+export default class extends Euler {
+  generatePositionVectors(
+    v: VectorType[],
+    dt: number,
+    p?: VectorType[]
+  ): VectorType[] {
+    const pFinal = [];
+    const vLen = v.length;
+
+    for (let i = 0; i < vLen; i++) {
+      let vI = v[i];
+      let pI = p[i];
+
+      pFinal[i] = this.p
+        .set({ x: pI.x, y: pI.y, z: pI.z })
+        .addScaledVector(dt, vI)
+        .toObject();
+    }
+
+    return pFinal;
+  }
+
+  generateVelocityVectors(
+    a: VectorType[],
+    dt: number,
+    v?: VectorType[]
+  ): VectorType[] {
+    const vFinal = [];
+    const vLen = v.length;
+
+    for (let i = 0; i < vLen; i++) {
+      let vI = v[i];
+      let aI = a[i];
+
+      vFinal[i] = this.v
+        .set({ x: vI.x, y: vI.y, z: vI.z })
+        .addScaledVector(dt, aI)
+        .toObject();
+    }
+
+    return vFinal;
+  }
+
+  iterate(): void {
+    const s = this.getStateVectors(this.masses);
+
+    const pCoeffs = [
+      0.3708351821753065,
+      0.16628476927529068,
+      -0.1091730577518966,
+      -0.19155388040992194,
+      -0.13739914490621316,
+      0.31684454977447707,
+      0.3249590053210324,
+      -0.24079742347807487,
+      -0.24079742347807487,
+      0.3249590053210324,
+      0.31684454977447707,
+      -0.13739914490621316,
+      -0.19155388040992194,
+      -0.1091730577518966,
+      0.16628476927529068,
+      0.3708351821753065
+    ];
+    const vCoeffs = [
+      0.741670364350613,
+      -0.4091008258000316,
+      0.1907547102962384,
+      -0.5738624711160822,
+      0.2990641813036559,
+      0.33462491824529816,
+      0.3152930923967666,
+      -0.7968879393529164,
+      0.3152930923967666,
+      0.33462491824529816,
+      0.2990641813036559,
+      -0.5738624711160822,
+      0.1907547102962384,
+      -0.4091008258000316,
+      0.741670364350613
+    ];
+
+    let p = s.p;
+    let v = s.v;
+
+    const coeffsLen = vCoeffs.length;
+
+    for (let i = 0; i < coeffsLen; i++) {
+      p = this.generatePositionVectors(v, this.dt * pCoeffs[i], p);
+      v = this.generateVelocityVectors(
+        this.generateAccelerationVectors(p),
+        this.dt * vCoeffs[i],
+        v
+      );
+    }
+
+    p = this.generatePositionVectors(v, this.dt * pCoeffs[coeffsLen], p);
+
+    this.updateStateVectors(p, v);
+
+    this.incrementElapsedTime();
+  }
+}

--- a/src/js/Physics/Integrators/index.ts
+++ b/src/js/Physics/Integrators/index.ts
@@ -10,6 +10,7 @@ import Nystrom6 from './Nystrom6';
 import RKN64 from './RKN64';
 import RKN12 from './RKN12';
 import Yoshida6 from './Yoshida6';
+import KahanLi8 from './KahanLi8';
 import { MassType } from '../types';
 
 export const integrators = [
@@ -24,7 +25,8 @@ export const integrators = [
   'Nystrom6',
   'RKN64',
   'RKN12',
-  'Yoshida6'
+  'Yoshida6',
+  'KahanLi8'
 ];
 
 export default function(
@@ -64,6 +66,8 @@ export default function(
       return new RKN12(config);
     case 'Yoshida6':
       return new Yoshida6(config);
+    case 'KahanLi8':
+      return new KahanLi8(config);
     default:
       return new RK4(config);
   }


### PR DESCRIPTION
I have found a couple of new integrators 😅 and I couldn't resist the urge to add them hehe... 🤣

KahanLi8 is an 8th order symplectic integrator. In my benchmarks it blew both PEFRL and Yoshida6 off the charts so it would be my goto integrator for long-time simulations. 🚀 

The commit-hook did work wonderfully as well 😉 now I can commit without having to be ashamed of my code 🤣 

