### PR TITLE
Free memory by properly disposing of the scene

### DIFF
--- a/src/js/scene/CustomEllipseCurve.ts
+++ b/src/js/scene/CustomEllipseCurve.ts
@@ -143,7 +143,10 @@ export default class extends Object3D {
       );
     };
 
-    this.add(new Line(ellipseGeometry, ellipseMaterial));
+    const mesh = new Line(ellipseGeometry, ellipseMaterial);
+    mesh.name = 'CustomEllipse';
+
+    this.add(mesh);
   }
 
   rotateAroundFocus(axisRotations: VectorType): void {
@@ -173,5 +176,15 @@ export default class extends Object3D {
     this.uniforms.aRotation.value = aRotation;
 
     this.rotateAroundFocus(axisRotations);
+  }
+
+  dispose() {
+    const customEllipse = this.getObjectByName('CustomEllipse');
+
+    if (customEllipse) {
+      customEllipse.geometry.dispose();
+      customEllipse.material.dispose();
+      this.remove(customEllipse);
+    }
   }
 }

--- a/src/js/scene/MassManifestation.js
+++ b/src/js/scene/MassManifestation.js
@@ -184,7 +184,13 @@ export default class extends THREE.Object3D {
   }
 
   removeTrail() {
-    this.remove(this.getObjectByName('Trail'));
+    const trail = this.getObjectByName('Trail');
+
+    if (trail) {
+      trail.geometry.dispose();
+      trail.material.dispose();
+      this.remove(trail);
+    }
   }
 
   createManifestation() {
@@ -211,6 +217,35 @@ export default class extends THREE.Object3D {
       trail.geometry.vertices.unshift({ x, y, z });
       trail.geometry.vertices.length = this.mass.trailVertices;
       trail.geometry.verticesNeedUpdate = true;
+    }
+  }
+
+  dispose() {
+    const main = this.getObjectByName('Main');
+
+    if (main) {
+      main.geometry.dispose();
+      if (main.material.map) main.material.map.dispose();
+      if (main.material.bumpMap) main.material.bumpMap.dispose();
+      main.material.dispose();
+      this.remove(main);
+    }
+
+    const trail = this.getObjectByName('Trail');
+
+    if (trail) {
+      trail.geometry.dispose();
+      trail.material.dispose();
+      this.remove(trail);
+    }
+
+    const clouds = this.getObjectByName('Clouds');
+
+    if (clouds) {
+      clouds.geometry.dispose();
+      clouds.material.map.dispose();
+      clouds.material.dispose();
+      this.remove(trail);
     }
   }
 }

--- a/src/js/scene/MassManifestation.js
+++ b/src/js/scene/MassManifestation.js
@@ -231,13 +231,7 @@ export default class extends THREE.Object3D {
       this.remove(main);
     }
 
-    const trail = this.getObjectByName('Trail');
-
-    if (trail) {
-      trail.geometry.dispose();
-      trail.material.dispose();
-      this.remove(trail);
-    }
+    this.removeTrail();
 
     const clouds = this.getObjectByName('Clouds');
 
@@ -245,7 +239,7 @@ export default class extends THREE.Object3D {
       clouds.geometry.dispose();
       clouds.material.map.dispose();
       clouds.material.dispose();
-      this.remove(trail);
+      this.remove(clouds);
     }
   }
 }

--- a/src/js/scene/Model.js
+++ b/src/js/scene/Model.js
@@ -41,4 +41,8 @@ export default class extends MassManifestation {
       }
     );
   }
+
+  dispose() {
+    //Need to look into how to go about this since models have a fairly deep and nested data structure.
+  }
 }

--- a/src/js/scene/ParticlesManifestation.ts
+++ b/src/js/scene/ParticlesManifestation.ts
@@ -36,6 +36,8 @@ export default class extends Object3D {
   }: ParticlesManifestationType) {
     super();
 
+    this.name = 'ParticlesManifestation';
+
     this.particles = particles;
 
     this.scenarioScale = scenarioScale;
@@ -136,5 +138,16 @@ export default class extends Object3D {
 
     geometry.attributes.size.needsUpdate = true;
     geometry.attributes.position.needsUpdate = true;
+  }
+
+  dispose() {
+    const system = this.getObjectByName('system');
+
+    if (system) {
+      system.geometry.dispose();
+      system.material.uniforms.texture.value.dispose();
+      system.material.dispose();
+      this.remove(system);
+    }
   }
 }

--- a/src/js/scene/Star.js
+++ b/src/js/scene/Star.js
@@ -16,7 +16,16 @@ export default class extends MassManifestation {
   }
 
   removeHabitableZone() {
-    this.remove(this.getObjectByName(`${this.mass.name} Habitable Zone`));
+    const habitableZone = this.getObjectByName(
+      `${this.mass.name} Habitable Zone`
+    );
+
+    if (habitableZone) {
+      const habitableZoneMain = habitableZone.getObjectByName('Main');
+      habitableZoneMain.geometry.dispose();
+      habitableZoneMain.material.dispose();
+      this.remove(habitableZone);
+    }
   }
 
   getReferenceOrbits(referenceOrbits) {
@@ -78,13 +87,40 @@ export default class extends MassManifestation {
 
     container.name = 'Reference Orbits';
 
+    mercuryOrbitCurve.name = 'Mercury';
+    earthOrbitCurve.name = 'Earth';
+
     container.add(mercuryOrbitCurve, earthOrbitCurve);
 
     this.add(container);
   }
 
   removeReferenceOrbits() {
-    this.remove(this.getObjectByName('Reference Orbits'));
+    const referenceOrbits = this.getObjectByName('Reference Orbits');
+
+    if (referenceOrbits) {
+      const mercuryOrbit = referenceOrbits.getObjectByName('Mercury');
+
+      const [mercuryOrbitChild] = mercuryOrbit.children;
+      mercuryOrbitChild.geometry.dispose();
+      mercuryOrbitChild.material.dispose();
+
+      mercuryOrbit.remove(mercuryOrbitChild);
+
+      referenceOrbits.remove(mercuryOrbit);
+
+      const earthOrbit = referenceOrbits.getObjectByName('Earth');
+
+      const [earthOrbitChild] = earthOrbit.children;
+      earthOrbitChild.geometry.dispose();
+      earthOrbitChild.material.dispose();
+
+      earthOrbit.remove(earthOrbitChild);
+
+      referenceOrbits.remove(earthOrbit);
+
+      this.remove(referenceOrbits);
+    }
   }
 
   getMain() {
@@ -145,5 +181,22 @@ export default class extends MassManifestation {
       trail.geometry.vertices.length = this.mass.trailVertices;
       trail.geometry.verticesNeedUpdate = true;
     }
+  }
+
+  dispose() {
+    const main = this.getObjectByName('Main');
+
+    if (main) {
+      main.geometry.dispose();
+      main.material.uniforms.texture.value.dispose();
+      main.material.dispose();
+      this.remove(main);
+    }
+
+    this.removeHabitableZone();
+
+    this.removeTrail();
+
+    this.removeReferenceOrbits();
   }
 }

--- a/src/js/scene/index.js
+++ b/src/js/scene/index.js
@@ -191,9 +191,14 @@ export default {
 
         if (newMasses.some(entry2 => entry1.name === entry2.name)) ++i;
         else {
-          previousMasses.splice(i, 1);
+          const massToBeDeleted = this.scene.getObjectByName(
+            previousMasses[i].name
+          );
 
-          this.scene.remove(this.scene.getObjectByName(entry1.name));
+          massToBeDeleted.dispose();
+          this.scene.remove(massToBeDeleted);
+
+          previousMasses.splice(i, 1);
         }
       }
 
@@ -931,7 +936,73 @@ export default {
   },
 
   reset() {
+    //Dispose of the camera controls
     this.camera && this.camera.controls.dispose();
+
+    //Dispose of all the mass manifestations
+    if (this.massManifestations)
+      this.massManifestations.forEach(manifestation => {
+        manifestation.dispose();
+        this.scene.remove(this.scene.getObjectByName(manifestation.name));
+      });
+
+    //Dispose of the particles system
+    if (this.particles) {
+      this.particles.dispose();
+      this.scene.remove(this.scene.getObjectByName('ParticlesManifestation'));
+    }
+
+    if (this.ellipseCurve) {
+      this.ellipseCurve.dispose();
+      this.scene.remove(this.ellipseCurve);
+    }
+
+    //Dispose of the scene and arena
+    let arena;
+
+    if (this.scene) {
+      arena = this.scene.getObjectByName('Arena');
+
+      if (arena) {
+        arena.geometry.dispose();
+        arena.material.map.dispose();
+        arena.material.dispose();
+        this.scene.remove(arena);
+      }
+
+      this.scene.dispose();
+    }
+
+    //Dispose of the renderer and although the garbage collector takes care of this, just to be sure
+    //Null the scene properties to make sure memory is freed up
+    if (this.renderer) {
+      this.renderer.renderLists.dispose();
+      this.renderer.dispose();
+
+      this.scenario.null;
+      this.webGlCanvas = null;
+      this.graphics2DCanvas = null;
+      this.graphics2D = null;
+      this.w = null;
+      this.h = null;
+      this.audio = null;
+      this.camera = null;
+      this.system = null;
+      this.renderer = null;
+      this.scene = null;
+      this.utilityVector = null;
+      this.barycenterPosition = null;
+      this.rotatingReferenceFrame = null;
+      this.rotatingVelocity = null;
+      this.manifestationPosition = null;
+      this.particlePhysics = null;
+      this.previousCameraFocus = null;
+      this.previousRotatingReferenceFrame = null;
+      this.previousIntegrator = null;
+      this.massManifestations = null;
+      this.particles = null;
+      this.ellipseCurve = null;
+    }
 
     cancelAnimationFrame(this.requestAnimationFrameId);
 

--- a/src/types/three.d.ts
+++ b/src/types/three.d.ts
@@ -26,6 +26,8 @@ declare module 'three' {
     frustumCulled: boolean;
     geometry: any;
     rotation: { x: number; y: number; z: number };
+    material: any;
+    remove(obj: Object3D): this;
     add(obj: Object3D): this;
     getObjectByName(name: string): Object3D;
   }


### PR DESCRIPTION
Big oversight; to free up memory, it is not sufficient to merely remove an object from its parent (ultimately the scene) or overwrite the property that refers to it - you have to manually dispose it: the JavaScript garbage collector does not take care of this. 

Good news is that having done some profiling, the changes introduced with this merge almost removes the problem of memory hogging completely. I say almost because I still need to look into how to properly dispose of models; tricky bastards. 

Will probably try to generalise how objects are disposed of in the future, but given the urgency of sorting this out, this will do for now since it does the job. 