### PR TITLE
add SOI-stuff

### DIFF
--- a/src/js/Physics/spacecraft/lambert.ts
+++ b/src/js/Physics/spacecraft/lambert.ts
@@ -1,3 +1,5 @@
+// Implementation from https://github.com/poliastro/poliastro/
+
 import H3 from '../vectors';
 import { VectorType, MassType, SOITree } from '../types';
 import { getDistanceParams } from '../utils';

--- a/src/js/Physics/types.ts
+++ b/src/js/Physics/types.ts
@@ -41,3 +41,13 @@ export interface TreeNodeType {
   mass: number;
   children: TreeNodeType[] | MassType[];
 }
+
+export interface SOITree {
+  name: string;
+  SOIradius: number;
+  children: Array<SOITree>;
+  m?: number;
+  x?: number;
+  y?: number;
+  z?: number;
+}


### PR DESCRIPTION
After a few days of silence, I'm back 😅 
What I've done here is adding two (exported) functions:
- `constructSOITree(masses: Array<MassType>): SOITree` , which constructs our tree data structure from the list of masses (scenario.masses in most cases).
- `findCurrentSOI(pos: MassType, tree: SOITree, masses: Array<MassType>): MassType` , which checks which body's SOI, pos is in. 
Exemple of usage: construct the tree once at the beginning of the simulation (if things are just orbiting each other). We will have to reconstruct it when bodies collide or are created. If we want to know which SOI a spacecraft is in we just call `findCurrentSOI(spacecraft, tree, scenario.masses)` and we will get the body. 

One thing I suggested isn't implemented yet, namely which SOIs we are passing through/which pertrubators we should choose. The dilemma is that they aren't the same. I see no problem in implementing both, I would like to know how you want to use them though. So I can tailor them for it. 