### PR TITLE
Do collisions after the particle system has iterated

### DIFF
--- a/src/js/scene/index.js
+++ b/src/js/scene/index.js
@@ -332,8 +332,9 @@ export default {
     const excessFragments =
       this.scenario.particles.max - totalWithAddedFragments;
 
-    if (excessFragments < 0)
+    if (excessFragments < 0) {
       this.particlePhysics.particles.splice(0, -excessFragments);
+    }
 
     const maxAngle = 45;
     const fragmentMass = 1.005570862e-29;
@@ -716,19 +717,19 @@ export default {
         this.rotatingReferenceFrame
       );
 
-    if (this.scenario.playing && this.scenario.collisions)
-      CollisionsService.doCollisions(
-        this.system.masses,
-        this.scenario.scale,
-        this.collisionCallback
-      );
-
     if (this.scenario.particles && this.scenario.playing)
       this.particlePhysics.iterate(
         oldMasses,
         this.system.masses,
         this.scenario.g,
         dt
+      );
+
+    if (this.scenario.playing && this.scenario.collisions)
+      CollisionsService.doCollisions(
+        this.system.masses,
+        this.scenario.scale,
+        this.collisionCallback
       );
 
     store.dispatch(


### PR DESCRIPTION
What happens otherwise is that the oldMasses array will contain the celestial object that was destroyed, and when the verlet particle integrator checks for collisions when it calculates the accelerations for the oldMasses, it will detect a collision between the object that collided and the particles produced from that collision, which is not the expected behaviour. The solution to this problem is either to remove the mass that collided from the old masses array, or for no price at all, simply do the collisions after the particles have had their new state vectors generated: we choose the latter.